### PR TITLE
Option to change the size of the playback button icons

### DIFF
--- a/src/org.gnome.shell.extensions.mediaplayer.gschema.xml
+++ b/src/org.gnome.shell.extensions.mediaplayer.gschema.xml
@@ -4,6 +4,12 @@
     <value nick='right' value='1'/>
     <value nick='volume-menu' value='2'/>
   </enum>
+  <enum id='org.gnome.shell.extensions.mediaplayer.button-sizes'>
+    <value nick='default' value='0'/>
+    <value nick='large' value='1'/>
+    <value nick='medium' value='2'/>
+    <value nick='small' value='3'/>
+  </enum>
   <schema id="org.gnome.shell.extensions.mediaplayer" path="/org/gnome/shell/extensions/mediaplayer/">
     <key name="indicator-position" enum="org.gnome.shell.extensions.mediaplayer.positions">
         <default>'volume-menu'</default>
@@ -18,6 +24,10 @@
         <default>false</default>
         <summary>Show the current tracks cover in the panel</summary>
         <description>Show the current tracks cover in the panel instead of an icon.</description>
+    </key>
+    <key name="button-icon-size" enum="org.gnome.shell.extensions.mediaplayer.button-sizes">
+        <default>'default'</default>
+        <summary>The size of the play control buttons</summary>
     </key>
     <key name="volume" type="b">
         <default>false</default>

--- a/src/player.js
+++ b/src/player.js
@@ -77,6 +77,7 @@ const PlayerState = new Lang.Class({
   showVolume: null,
   showPosition: null,
   hideStockMpris: null,
+  buttonIconSize: null,
   showStopButton: null,
   showLoopStatus: null,
   showPlayStatusIcon: null,
@@ -278,6 +279,12 @@ const MPRISPlayer = new Lang.Class({
             if (this.state.showLoopStatus !== this.showLoopStatus) {
               this.emit('update-player-state', new PlayerState({showLoopStatus: this.showLoopStatus}));
             }
+          }))
+        );
+        // buttonIconSize setting
+        this._signalsId.push(
+          this._settings.connect("changed::" + Settings.MEDIAPLAYER_BUTTON_ICON_SIZE_KEY, Lang.bind(this, function(settings, key) {
+            this.emit('update-player-state', new PlayerState({buttonIconSize: settings.get_enum(key)}));
           }))
         );
         // showPlaylists setting
@@ -762,6 +769,10 @@ const MPRISPlayer = new Lang.Class({
 
     get showStopButton() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_STOP_BUTTON_KEY) && !this.playerIsBroken;
+    },
+
+    get buttonIconSize() {
+      return this._settings.get_enum(Settings.MEDIAPLAYER_BUTTON_ICON_SIZE_KEY);
     },
 
     get showVolume() {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -122,7 +122,17 @@ function init() {
             type: "b",
             label: _("Show Shuffle and Repeat Buttons in the Player Controls"),
             help: _("Very few player implement this correctly, if at all.")
-        }
+        },
+        button_icon_size: {
+            type: "e",
+            label: _("Player button size"),
+            list: [
+                { nick: 'default', name: _("Default"), id: 0 },
+                { nick: 'large', name: _("Large"), id: 1 },
+                { nick: 'medium', name: _("Medium"), id: 2 },
+                { nick: 'small', name: _("Small"), id: 3 }
+            ]
+        },
     };
 
     if (Gtk.get_minor_version() > 19) {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -189,12 +189,12 @@ function createEnumSetting(settings, setting) {
 
     settings[setting].list.forEach(function(item) {
       setting_enum.append(item.nick, item.name);
-      if (item.id == gsettings.get_enum(setting.replace('_', '-'))) {
+      if (item.id == gsettings.get_enum(setting.replace(/_/g, '-'))) {
         setting_enum.set_active(item.id);
       }
     });
 
-    gsettings.bind(setting.replace('_', '-'), setting_enum, 'active-id', Gio.SettingsBindFlags.DEFAULT);
+    gsettings.bind(setting.replace(/_/g, '-'), setting_enum, 'active-id', Gio.SettingsBindFlags.DEFAULT);
 
     if (settings[setting].help) {
         setting_label.set_tooltip_text(settings[setting].help);
@@ -216,9 +216,9 @@ function createStringSetting(settings, setting) {
     let setting_label = new Gtk.Label({label: settings[setting].label,
                                        xalign: 0 });
 
-    let setting_string = new Gtk.Entry({text: gsettings.get_string(setting.replace('_', '-'))});
+    let setting_string = new Gtk.Entry({text: gsettings.get_string(setting.replace(/_/g, '-'))});
     setting_string.set_width_chars(30);
-    gsettings.bind(setting.replace('_', '-') , setting_string, 'text', Gio.SettingsBindFlags.DEFAULT);
+    gsettings.bind(setting.replace(/_/g, '-') , setting_string, 'text', Gio.SettingsBindFlags.DEFAULT);
 
     if (settings[setting].help) {
         setting_label.set_tooltip_text(settings[setting].help);
@@ -246,7 +246,7 @@ function createIntSetting(settings, setting) {
                                           climb_rate: 1.0,
                                           digits: 0,
                                           snap_to_ticks: true});
-    gsettings.bind(setting.replace('_', '-') , setting_int, 'value', Gio.SettingsBindFlags.DEFAULT);
+    gsettings.bind(setting.replace(/_/g, '-') , setting_int, 'value', Gio.SettingsBindFlags.DEFAULT);
 
     if (settings[setting].help) {
         setting_label.set_tooltip_text(settings[setting].help);
@@ -267,8 +267,8 @@ function createBoolSetting(settings, setting) {
     let setting_label = new Gtk.Label({label: settings[setting].label,
                                        xalign: 0 });
 
-    let setting_switch = new Gtk.Switch({active: gsettings.get_boolean(setting.replace('_', '-'))});
-    gsettings.bind(setting.replace('_', '-') , setting_switch, 'active', Gio.SettingsBindFlags.DEFAULT);
+    let setting_switch = new Gtk.Switch({active: gsettings.get_boolean(setting.replace(/_/g, '-'))});
+    gsettings.bind(setting.replace(/_/g, '-') , setting_switch, 'active', Gio.SettingsBindFlags.DEFAULT);
 
     if (settings[setting].help) {
         setting_label.set_tooltip_text(settings[setting].help);

--- a/src/settings.js
+++ b/src/settings.js
@@ -36,6 +36,7 @@ const MEDIAPLAYER_HIDE_AGGINDICATOR_KEY = 'hide-aggindicator';
 const MEDIAPLAYER_POSITION_KEY = 'position';
 const MEDIAPLAYER_PLAYLISTS_KEY = 'playlists';
 const MEDIAPLAYER_STOP_BUTTON_KEY = 'stop-button';
+const MEDIAPLAYER_BUTTON_ICON_SIZE_KEY = 'button-icon-size';
 const MEDIAPLAYER_PLAYLIST_TITLE_KEY = 'playlist-title';
 const MEDIAPLAYER_TRACKLIST_KEY = 'tracklist';
 const MEDIAPLAYER_TRACKLIST_RATING_KEY = 'tracklist-rating';
@@ -52,6 +53,13 @@ const IndicatorPosition = {
     CENTER: 0,
     RIGHT: 1,
     VOLUMEMENU: 2
+};
+
+const ButtonIconSizes = {
+    DEFAULT: 0,
+    LARGE: 1,
+    MEDIUM: 2,
+    SMALL: 3
 };
 
 const Status = {

--- a/src/ui.js
+++ b/src/ui.js
@@ -210,6 +210,13 @@ const PlayerUI = new Lang.Class({
       }
     }
 
+    if (newState.buttonIconSize !== null) {
+      this.prevButton.setIconSize(this.state.buttonIconSize);
+      this.playButton.setIconSize(this.state.buttonIconSize);
+      this.stopButton.setIconSize(this.state.buttonIconSize);
+      this.nextButton.setIconSize(this.state.buttonIconSize);
+    }
+
     if (newState.shuffle !== null) {
       this.shuffleLoopStatus.setShuffle(this.state.shuffle);
     }

--- a/src/widget.js
+++ b/src/widget.js
@@ -332,7 +332,16 @@ const PlayerButton = new Lang.Class({
     Name: "PlayerButton",
 
     _init: function(icon, callback) {
-        this.actor = new St.Button({child: new St.Icon({icon_name: icon, style_class: 'popup-menu-icon'})});
+        let button_size = Settings.gsettings.get_enum(Settings.MEDIAPLAYER_BUTTON_ICON_SIZE_KEY);
+        let style_class = 'popup-menu-icon';
+        if (button_size == Settings.ButtonIconSizes.LARGE) {
+            style_class = 'shell-mount-operation-icon';
+        } else if (button_size == Settings.ButtonIconSizes.MEDIUM) {
+            style_class = 'nm-dialog-header-icon';
+        } else if (button_size == Settings.ButtonIconSizes.SMALL) {
+            style_class = 'nm-dialog-icon';
+        }
+        this.actor = new St.Button({child: new St.Icon({icon_name: icon, style_class: style_class})});
         this.actor.opacity = 204;
         this.actor._delegate = this;
         this.actor.connect('clicked', callback);
@@ -343,6 +352,17 @@ const PlayerButton = new Lang.Class({
 
     setIcon: function(icon) {
         this.actor.child.icon_name = icon;
+    },
+
+    setIconSize: function(size) {
+        if (size == Settings.ButtonIconSizes.DEFAULT)
+            this.actor.child.style_class = 'popup-menu-icon';
+        else if (size == Settings.ButtonIconSizes.LARGE)
+            this.actor.child.style_class = 'shell-mount-operation-icon';
+        else if (size == Settings.ButtonIconSizes.MEDIUM)
+            this.actor.child.style_class = 'nm-dialog-header-icon';
+        else if (size == Settings.ButtonIconSizes.SMALL)
+            this.actor.child.style_class = 'nm-dialog-icon';
     },
 
     enable: function() {


### PR DESCRIPTION
Currently on high DPI screens, the buttons to control playback are very small and somewhat hard to target.
This pull requests implements three different selectable sizes (apart from the existing one) to accommodate more screen resolutions.