### PR TITLE
build: fix shebang line

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env bash
 
 # Possible arguments
 #./build --install


### PR DESCRIPTION
This pull-request fixes two small issues with the build script:
 * to find out the path to the shell (sh), we should use the handy program env.
   in short, this will make of use of the user's $PATH variable.
 * the build script uses the keyword `select`. however, select is not available
   in sh, at least on my debian system :-). thus, we should use bash in the
   shebang line. bash supports `select`.