### PR TITLE
Add support to hide the player state icon

### DIFF
--- a/src/org.gnome.shell.extensions.mediaplayer.gschema.xml
+++ b/src/org.gnome.shell.extensions.mediaplayer.gschema.xml
@@ -74,6 +74,11 @@
         <summary>Status text size</summary>
         <description>The the maximum width before the title gets an ellipsis. Default is 300px.</description>
     </key>
+    <key name="play-state-icon" type="b">
+        <default>true</default>
+        <summary>Show a play state icon in the indicator</summary>
+        <description>Show a play state icon in the indicator.</description>
+    </key>
     <key name="volumemenu" type="b">
         <default>true</default>
         <summary>Show the media player in the volume menu</summary>

--- a/src/panel.js
+++ b/src/panel.js
@@ -91,6 +91,11 @@ const IndicatorMixin = {
           this._prefWidth = settings.get_int(key);
           this._updatePanel();
     })));
+    this._signalsId.push(this._settings.connect("changed::" + Settings.MEDIAPLAYER_PLAY_STATE_ICON_KEY,
+      Lang.bind(this, function(settings, key) {
+          this._showPlayStateIcon = settings.get_boolean(key);
+          this._updatePanel();
+    })));
   },
 
   _disconnectSignals: function() {
@@ -108,7 +113,7 @@ const IndicatorMixin = {
 
   _updatePanel: function() {
     let state = this.state;
-    if (state.status) {
+    if (state.status && this._showPlayStateIcon) {
       if (state.status == Settings.Status.PLAY) {
         this._secondaryIndicator.icon_name = "media-playback-start-symbolic";
       }
@@ -121,6 +126,8 @@ const IndicatorMixin = {
       this._secondaryIndicator.show();
       this._secondaryIndicator.set_width(-1);
       this.indicators.show();
+    } else {
+        this._secondaryIndicator.hide();
     }
 
     if(this._stateTemplate.length === 0 || state.status == Settings.Status.STOP) {
@@ -184,6 +191,7 @@ var PanelIndicator = new Lang.Class({
     this._useCoverInPanel = this._settings.get_boolean(Settings.MEDIAPLAYER_COVER_STATUS_KEY);
     this._stateTemplate = this._settings.get_string(Settings.MEDIAPLAYER_STATUS_TEXT_KEY);
     this._prefWidth = this._settings.get_int(Settings.MEDIAPLAYER_STATUS_SIZE_KEY);
+    this._showPlayStateIcon = this._settings.get_boolean(Settings.MEDIAPLAYER_PLAY_STATE_ICON_KEY);
     this._statusTextWidth = 0;
     this._stateText = '';
     this._signalsId = [];

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -99,6 +99,11 @@ const Settings = {
         step: 5,
         default: 300
     },
+    'play-state-icon': {
+        type: "b",
+        tab: "i",
+        label: _("Show the Indicator Player State Icon")
+    },
     'button-icon-style': {
         type: "e",
         tab: "p",

--- a/src/settings.js
+++ b/src/settings.js
@@ -31,6 +31,7 @@ var MEDIAPLAYER_INDICATOR_POSITION_KEY = 'indicator-position';
 var MEDIAPLAYER_COVER_STATUS_KEY = 'cover-status';
 var MEDIAPLAYER_STATUS_TEXT_KEY = 'status-text';
 var MEDIAPLAYER_STATUS_SIZE_KEY = 'status-size';
+var MEDIAPLAYER_PLAY_STATE_ICON_KEY = 'play-state-icon';
 var MEDIAPLAYER_VOLUME_KEY = 'volume';
 var MEDIAPLAYER_HIDE_AGGINDICATOR_KEY = 'hide-aggindicator';
 var MEDIAPLAYER_POSITION_KEY = 'position';


### PR DESCRIPTION
This pull-request adds support to hide the player state icon (i.e., secondary indicator icon) as described in this comment here :-)
https://github.com/JasonLG1979/gnome-shell-extensions-mediaplayer/issues/403#issuecomment-331173064