### PR TITLE
Add gnome-shell 3.30 to metadata.json

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,6 +3,6 @@
 "name": "Media Player Indicator",
 "description": "Control MPRIS Version 2 Capable Media Players.",
 "original-author": "eon@patapon.info",
-"shell-version": ["3.18", "3.20", "3.22", "3.24", "3.26", "3.28"],
+  "shell-version": ["3.18", "3.20", "3.22", "3.24", "3.26", "3.28", "3.30"],
 "url": "https://github.com/JasonLG1979/gnome-shell-extensions-mediaplayer/"
 }


### PR DESCRIPTION
Tested on Arch with gnome-shell 3.30 after the update that came yesterday.