### PR TITLE
Bug 448 alignment tweak

### DIFF
--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -4,6 +4,16 @@
     padding: 0;
 }
 
+/*
+ * This is ugly, but seems to work - narrow the "spacer"/alignment boxes
+ *
+ * The other option would be negative margins, but that
+ * breaks things.
+ */
+.panel-media-indicator .popup-sub-menu > * > * > :first-child {
+    width: 14px;
+}
+
 .player-buttons {
     spacing: 2px;
 }

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -1,6 +1,5 @@
 .panel-media-indicator .popup-sub-menu > * > * > :first-child,
-.panel-media-indicator .popup-sub-menu > * > * > :last-child > :first-child,
-.panel-media-indicator .popup-sub-menu > * > * > :last-child > :first-child > :first-child {
+.panel-media-indicator .popup-sub-menu > * > * > :last-child > :first-child {
     margin:  0;
     padding: 0;
 }


### PR DESCRIPTION
Tweaks the existing fix for bug #448 to:
 * Stop the first star and "previous" button losing their margins when siblings don't
 * Fudge a spacer to give perfect centre alignment