### PR TITLE
Port to GNOME Shell 3.32.

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -30,10 +30,9 @@ const DBusIface = Me.imports.dbus;
 const UI = Me.imports.ui;
 
 
-var PlayerManager = new Lang.Class({
-    Name: 'PlayerManager',
+var PlayerManager = class PlayerManager {
 
-    _init: function(menu, desiredMenuPosition) {
+    constructor(menu, desiredMenuPosition) {
         this._disabling = false;
         // the menu
         this.menu = menu;
@@ -100,11 +99,11 @@ var PlayerManager = new Lang.Class({
                 }
             }
         ));
-    },
+    }
 
     get activePlayer() {
       return this._activePlayer;
-    },
+    }
 
     set activePlayer(player) {
 
@@ -130,9 +129,9 @@ var PlayerManager = new Lang.Class({
         this.showActivePlayer();
       }
       this.emit('player-active-update', player.state);
-    },
+    }
 
-    showActivePlayer: function() {
+    showActivePlayer() {
       if (!this._activePlayer || !this.menu.actor.visible) {
         return;
       }
@@ -142,21 +141,21 @@ var PlayerManager = new Lang.Class({
           break;
         }
       }
-    },
+    }
 
-    closeAllPlayers: function() {
+    closeAllPlayers() {
       for (let owner in this._players) {
         if (this._players[owner].ui.menu) {
           this._players[owner].ui.menu.close();
         }
       }
-    },
+    }
 
-    nbPlayers: function() {
+    nbPlayers() {
       return Object.keys(this._players).length;
-    },
+    }
 
-    getPlayersByStatus: function(status, preference) {
+    getPlayersByStatus(status, preference) {
       // Return a list of running players by status and preference
       // preference is a player instance, if found in the list
       // it will be put in the first position
@@ -176,25 +175,25 @@ var PlayerManager = new Lang.Class({
           return 1;
         return 0;
       });
-    },
+    }
 
-    _isInstance: function(busName) {
+    _isInstance(busName) {
         // MPRIS instances are in the form
         //   org.mpris.MediaPlayer2.name.instanceXXXX
         // ...except for VLC, which to this day uses
         //   org.mpris.MediaPlayer2.name-XXXX
         return busName.split('.').length > 4 ||
                 /^org\.mpris\.MediaPlayer2\.vlc-\d+$/.test(busName);
-    },
+    }
 
-    _addPlayer: function(busName, owner) {
+    _addPlayer(busName, owner) {
       // Give players 1 sec to populate their interfaces before actually adding them.
       if (this._addPlayerTimeOutIds[busName] && this._addPlayerTimeOutIds[busName] !== 0) {
         Mainloop.source_remove(this._addPlayerTimeOutIds[busName]);
         this._addPlayerTimeOutIds[busName] = 0;
       }
       this._addPlayerTimeOutIds[busName] = Mainloop.timeout_add_seconds(1, Lang.bind(this, function() {
-          this._addPlayerTimeOutIds[busName] = 0;       
+          this._addPlayerTimeOutIds[busName] = 0;
           if (this._players[owner]) {
               let prevName = this._players[owner].player.busName;
               // HAVE:       ADDING:     ACTION:
@@ -226,25 +225,25 @@ var PlayerManager = new Lang.Class({
           }
           return false;
       }));
-    },
+    }
 
-    _onPlayerUpdate: function(player, newState) {
+    _onPlayerUpdate(player, newState) {
       if (newState.status)
         this._refreshActivePlayer(player);
-    },
+    }
 
-    _onActivePlayerUpdate: function(player, newState) {
+    _onActivePlayerUpdate(player, newState) {
       this.emit('player-active-update', newState);
-    },
+    }
 
-    _addPlayerToMenu: function(owner) {
-      let actualPos = this.desiredMenuPosition + this.nbPlayers();  
+    _addPlayerToMenu(owner) {
+      let actualPos = this.desiredMenuPosition + this.nbPlayers();
       let playerItem = this._players[owner];
       this.menu.addMenuItem(playerItem.ui, actualPos);
       this._refreshActivePlayer(playerItem.player);
-    },
+    }
 
-    _getMenuItem: function(position) {
+    _getMenuItem(position) {
         let items = this.menu.box.get_children().map(function(actor) {
             return actor._delegate;
         });
@@ -252,15 +251,15 @@ var PlayerManager = new Lang.Class({
             return items[position];
         else
             return null;
-    },
+    }
 
-    _removeMenuItem: function(position) {
+    _removeMenuItem(position) {
         let item = this._getMenuItem(position);
         if (item)
             item.destroy();
-    },
+    }
 
-    _getPlayerMenuPosition: function(ui) {
+    _getPlayerMenuPosition(ui) {
         let items = this.menu.box.get_children().map(function(actor) {
             return actor._delegate;
         });
@@ -269,9 +268,9 @@ var PlayerManager = new Lang.Class({
                 return i;
         }
         return null;
-    },
+    }
 
-    _removePlayerFromMenu: function(busName, owner) {
+    _removePlayerFromMenu(busName, owner) {
         if (this._players[owner]) {
             for (let id in this._players[owner].signals)
                 this._players[owner].player.disconnect(this._players[owner].signals[id]);
@@ -287,18 +286,18 @@ var PlayerManager = new Lang.Class({
         if (this.nbPlayers() === 0) {
           this.emit('disconnect-signals');
        }
-    },
+    }
 
-    _changePlayerOwner: function(busName, oldOwner, newOwner) {
+    _changePlayerOwner(busName, oldOwner, newOwner) {
         if (this._players[oldOwner] && busName == this._players[oldOwner].player.busName) {
             this._players[newOwner] = this._players[oldOwner];
             this._players[newOwner].player.owner = newOwner;
             delete this._players[oldOwner];
         }
         this._refreshActivePlayer(this._players[newOwner].player);
-    },
+    }
 
-    _refreshActivePlayer: function(player) {
+    _refreshActivePlayer(player) {
       // Display current status in the top panel
       if (this.nbPlayers() > 0) {
         // Get the first player
@@ -314,9 +313,9 @@ var PlayerManager = new Lang.Class({
       else {
         this.activePlayer = null;
       }
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this._disabling = true;
         this._settings.disconnect(this._settingChangeId);
         if (this._ownerChangedId)
@@ -331,5 +330,5 @@ var PlayerManager = new Lang.Class({
             }
         }
     }
-});
+};
 Signals.addSignalMethods(PlayerManager.prototype);

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,6 +3,6 @@
 "name": "Media Player Indicator",
 "description": "Control MPRIS Version 2 Capable Media Players.",
 "original-author": "eon@patapon.info",
-  "shell-version": ["3.18", "3.20", "3.22", "3.24", "3.26", "3.28", "3.30"],
+  "shell-version": ["3.32"],
 "url": "https://github.com/JasonLG1979/gnome-shell-extensions-mediaplayer/"
 }

--- a/src/panel.js
+++ b/src/panel.js
@@ -21,6 +21,7 @@
 
 const Lang = imports.lang;
 const Clutter = imports.gi.Clutter;
+const GObject = imports.gi.GObject;
 const Pango = imports.gi.Pango;
 const St = imports.gi.St;
 const PanelMenu = imports.ui.panelMenu;
@@ -134,7 +135,7 @@ const IndicatorMixin = {
       this._thirdIndicator.clutter_text.set_markup('');
       this._statusTextWidth = 0;
       this._stateText = '';
-      this._thirdIndicator.hide();      
+      this._thirdIndicator.hide();
     }
     else if (state.playerName || state.trackTitle || state.trackArtist || state.trackAlbum) {
       let stateText = this.compileTemplate(this._stateTemplate, state);
@@ -164,7 +165,7 @@ const IndicatorMixin = {
   },
 
   _commonOnActivePlayerRemove: function() {
-    this._primaryIndicator.icon_name = 'audio-x-generic-symbolic';    
+    this._primaryIndicator.icon_name = 'audio-x-generic-symbolic';
     this._thirdIndicator.clutter_text.set_markup('');
     this._thirdIndicator.set_width(0);
     this._secondaryIndicator.set_width(0);
@@ -174,12 +175,10 @@ const IndicatorMixin = {
   }
 };
 
-var PanelIndicator = new Lang.Class({
-  Name: 'PanelIndicator',
-  Extends: PanelMenu.Button,
+var PanelIndicator = GObject.registerClass(class PanelIndicator extends PanelMenu.Button {
 
-  _init: function() {
-    this.parent(0.0, "mediaplayer");
+  _init() {
+    super._init(0.0, "mediaplayer");
 
     this._manager = null;
     this.actor.add_style_class_name('panel-status-button');
@@ -216,32 +215,30 @@ var PanelIndicator = new Lang.Class({
     this.actor.add_actor(this.indicators);
     this.actor.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
     this.actor.hide();
-  },
+  }
 
   // Override PanelMenu.Button._onEvent
-  _onEvent: function(actor, event) {
+  _onEvent(actor, event) {
     if (this._onButtonEvent(actor, event) == Clutter.EVENT_PROPAGATE)
-      this.parent(actor, event);
-  },
+      super._onEvent(actor, event);
+  }
 
-  _onActivePlayerUpdate: function(state) {
+  _onActivePlayerUpdate(state) {
     if (this.manager.activePlayer) {
       this.actor.show();
     }
-  },
+  }
 
-  _onActivePlayerRemove: function() {
+  _onActivePlayerRemove() {
     this.actor.hide();
   }
 });
 Util._extends(PanelIndicator, IndicatorMixin);
 
-var AggregateMenuIndicator = new Lang.Class({
-  Name: 'AggregateMenuIndicator',
-  Extends: PanelMenu.SystemIndicator,
+var AggregateMenuIndicator = class AggregateMenuIndicator extends PanelMenu.SystemIndicator {
 
-  _init: function() {
-    this.parent();
+  constructor() {
+    super();
 
     this._manager = null;
     this.compileTemplate = Util.compileTemplate;
@@ -279,9 +276,9 @@ var AggregateMenuIndicator = new Lang.Class({
         this.indicators.show();
       }
     }));
-  },
+  }
 
-  _onActivePlayerUpdate: function(state) {
+  _onActivePlayerUpdate(state) {
     let alwaysHide = this._settings.get_boolean(Settings.MEDIAPLAYER_HIDE_AGGINDICATOR_KEY);
     if (state.status && state.status === Settings.Status.STOP || alwaysHide) {
       this.indicators.hide();
@@ -289,10 +286,10 @@ var AggregateMenuIndicator = new Lang.Class({
     else if (state.status && !alwaysHide) {
       this.indicators.show();
     }
-  },
+  }
 
-  _onActivePlayerRemove: function() {
+  _onActivePlayerRemove() {
     this.indicators.hide();
   }
-});
+};
 Util._extends(AggregateMenuIndicator, IndicatorMixin);

--- a/src/player.js
+++ b/src/player.js
@@ -35,86 +35,85 @@ const Settings = Me.imports.settings;
 const Util = Me.imports.util;
 
 
-var PlayerState = new Lang.Class({
-  Name: 'PlayerState',
+var PlayerState = class PlayerState {
 
-  _init: function(params) {
+  constructor(params) {
+
+    this.playerName = null;
+    this.desktopEntry = null;
+    this.status = null;
+
+    this.playlistObj = null;
+    this.playlists = null;
+    this.playlistCount = null;
+    this.orderings = null;
+
+    this.trackListMetaData = null;
+
+    this.trackTime = null;
+    this.trackDuration = null;
+    this.trackPosition = null;
+    this.trackTitle = null;
+    this.trackAlbum = null;
+    this.trackArtist = null;
+    this.trackUrl = null;
+    this.trackCoverUrl = null;
+    this.trackLength = null;
+    this.trackObj = null;
+    this.trackRating = null;
+    this.fallbackIcon = null;
+
+    this.showPlaylist = null;
+    this.showTracklist = null;
+    this.showRating = null;
+    this.showVolume = null;
+    this.showPosition = null;
+    this.hideStockMpris = null;
+    this.buttonIconStyle = null;
+    this.showStopButton = null;
+    this.showLoopStatus = null;
+    this.showPlayStatusIcon = null;
+
+    this.showTracklistRating = null;
+    this.updatedMetadata = null;
+    this.updatedPlaylist = null;
+    this.hasTrackList = null;
+    this.canPlay = null;
+    this.canPause = null;
+    this.canSeek = null;
+    this.canGoNext = null;
+    this.canGoPrevious = null;
+
+    this.volume = null;
+    this.showPlaylistTitle = null;
+    this.playlistTitle = null;
+
+    this.getPlaylists = null;
+
+    this.isRhythmboxStream = null;
+
+    this.shuffle = null;
+    this.loopStatus = null;
+
+    this.timeFresh = null;
+
+    this.emitSignal = null;
+
     this.update(params || {});
-  },
+  }
 
-  update: function(state) {
+  update(state) {
     for (let key in state) {
       if (state[key] !== null)
         this[key] = state[key];
     }
-  },
-
-  playerName: null,
-  desktopEntry: null,
-  status: null,
-
-  playlistObj: null,
-  playlists: null,
-  playlistCount: null,
-  orderings: null,
-
-  trackListMetaData: null,
-
-  trackTime: null,
-  trackDuration: null,
-  trackPosition: null,
-  trackTitle: null,
-  trackAlbum: null,
-  trackArtist: null,
-  trackUrl: null,
-  trackCoverUrl: null,
-  trackLength: null,
-  trackObj: null,
-  trackRating: null,
-  fallbackIcon: null,
-
-  showPlaylist: null,
-  showTracklist: null,
-  showRating: null,
-  showVolume: null,
-  showPosition: null,
-  hideStockMpris: null,
-  buttonIconStyle: null,
-  showStopButton: null,
-  showLoopStatus: null,
-  showPlayStatusIcon: null,
-
-  showTracklistRating: null,
-  updatedMetadata: null,
-  updatedPlaylist: null,
-  hasTrackList: null,
-  canPlay: null,
-  canPause: null,
-  canSeek: null,
-  canGoNext: null,
-  canGoPrevious: null,
-
-  volume: null,
-  showPlaylistTitle: null,
-  playlistTitle: null,
-
-  getPlaylists: null,
-
-  isRhythmboxStream: null,
-
-  shuffle: null,
-  loopStatus: null,
-
-  timeFresh: null,
-
-  emitSignal: null,
-});
+  }
+};
 
 
-var MPRISPlayer = new Lang.Class({
-    Name: 'MPRISPlayer',
+var MPRISPlayer = class MPRISPlayer {
 
-    _init: function(busName, owner) {
+    constructor(busName, owner) {
         let baseName = busName.split('.')[3];
 
         this.state = new PlayerState();
@@ -189,10 +188,9 @@ var MPRISPlayer = new Lang.Class({
             this._onStatusChange(state);
           this.emit('player-update', state);
         }));
+    }
 
-    },
-
-    _init2: function() {
+    _init2() {
         // Wait for all DBus callbacks to continue
         if (this._mediaServer !== null
             && this._mediaServerPlayer !== null
@@ -203,9 +201,9 @@ var MPRISPlayer = new Lang.Class({
             && this._prop !== null) {
             this._init3();
         }
-    },
+    }
 
-    _init3: function() {
+    _init3() {
         if (Settings.MINOR_VERSION > 19) {
         // Versions before 3.20 don't have Mpris built-in.
         // hideStockMpris setting
@@ -226,7 +224,7 @@ var MPRISPlayer = new Lang.Class({
               else {
                 this.emit('update-player-state', new PlayerState({showVolume: false}));
               }
-            }              
+            }
           }))
         );
         // showPosition setting
@@ -341,7 +339,7 @@ var MPRISPlayer = new Lang.Class({
               let afterTrackIdIndex = this._trackIds.indexOf(afterTrackId);
               if (afterTrackIdIndex !== -1) {
                 insertIndex = afterTrackIdIndex + 1;
-              } 
+              }
             }
             if (insertIndex !== -1) {
               let metadata = {};
@@ -470,14 +468,14 @@ var MPRISPlayer = new Lang.Class({
                 newState.getPlaylists = true;
               }
               else {
-                newState.getPlaylists = null;              
+                newState.getPlaylists = null;
               }
             }
           }
 
           if (props.ActivePlaylist) {
             let [playlistObj, playlistTitle] = props.ActivePlaylist.deep_unpack()[1];
-            
+
             if (this.state.playlistObj !== playlistObj) {
               newState.playlistObj = playlistObj;
               newState.emitSignal = true;
@@ -548,9 +546,9 @@ var MPRISPlayer = new Lang.Class({
           this.app = appSys.lookup_app(this.desktopEntry + ".desktop");
         }
         this.populate();
-    },
+    }
 
-    populate: function() {
+    populate() {
       // The Tracks prop value is never updated so it's value is only good
       // for right after the player is created after that we rely on
       // the TrackListReplaced, TrackAdded, and TrackRemoved signals
@@ -592,7 +590,7 @@ var MPRISPlayer = new Lang.Class({
       }
 
       this.parseMetadata(this._mediaServerPlayer.Metadata, newState);
-      
+
       //Delay calls 1 sec because some players make the interface available without data available in the beginning
 
       if (newState.playlistCount > 0 && newState.playlistTitle) {
@@ -619,21 +617,21 @@ var MPRISPlayer = new Lang.Class({
       }
 
       this.emit('update-player-state', newState);
-    },
+    }
 
-    _checkTrackIds: function(trackIds) {
+    _checkTrackIds(trackIds) {
       if (!trackIds || !Array.isArray(trackIds)) {
         trackIds = [];
       }
       return trackIds;
-    },
+    }
 
-    _checkOrderings: function(orderings) {
+    _checkOrderings(orderings) {
       if (!orderings || !Array.isArray(orderings) || orderings.length < 1) {
         orderings = ['Alphabetical'];
       }
       return orderings;
-    },
+    }
 
     set trackTime(value) {
       // Assume that if our trackTime is equal to or greater than
@@ -645,13 +643,13 @@ var MPRISPlayer = new Lang.Class({
       let newState = new PlayerState();
       this._trackTime = value;
       newState.trackTime = value;
-      newState.trackPosition = this._formatTime(value);      
+      newState.trackPosition = this._formatTime(value);
       this.emit('update-player-state', newState);
-    },
+    }
 
     get trackTime() {
       return this._trackTime;
-    },
+    }
 
     get canGoNext() {
       let canGoNext = this._mediaServerPlayer.CanGoNext;
@@ -659,7 +657,7 @@ var MPRISPlayer = new Lang.Class({
         canGoNext = true;
       }
       return canGoNext;
-    },
+    }
 
     get canGoPrevious() {
       let canGoPrevious = this._mediaServerPlayer.CanGoPrevious;
@@ -667,7 +665,7 @@ var MPRISPlayer = new Lang.Class({
         canGoPrevious = true;
       }
       return canGoPrevious;
-    },
+    }
 
     get canPlay() {
       let canPlay = this._mediaServerPlayer.CanPlay;
@@ -675,7 +673,7 @@ var MPRISPlayer = new Lang.Class({
         canPlay = true;
       }
       return canPlay;
-    },
+    }
 
     get canPause() {
       let canPause = this._mediaServerPlayer.CanPause;
@@ -683,19 +681,19 @@ var MPRISPlayer = new Lang.Class({
         canPause = true;
       }
       return canPause;
-    },
+    }
 
     get canQuit() {
       return this._mediaServer.CanQuit || false;
-    },
+    }
 
     get canSeek() {
       return this._mediaServerPlayer.CanSeek || false;
-    },
+    }
 
     get hasTrackList() {
       return this._mediaServer.HasTrackList || false;
-    },
+    }
 
     get volume() {
       let volume = this._mediaServerPlayer.Volume;
@@ -706,50 +704,50 @@ var MPRISPlayer = new Lang.Class({
         volume = Math.pow(volume, 1 / 3);
       }
       return volume;
-    },
+    }
 
     set volume(volume) {
       if (this.hasWrongVolumeScaling) {
         volume = Math.pow(volume, 3);
       }
       this._mediaServerPlayer.Volume = volume;
-    },
+    }
 
     get shuffle() {
       return this._mediaServerPlayer.Shuffle || false;
-    },
+    }
 
     set shuffle(shuffle) {
       if (this._mediaServerPlayer.Shuffle !== null) {
         this._mediaServerPlayer.Shuffle = shuffle;
       }
-    },
+    }
 
     get loopStatus() {
       return this._mediaServerPlayer.LoopStatus || 'None';
-    },
+    }
 
     set loopStatus(loopStatus) {
       if (this._mediaServerPlayer.LoopStatus !== null) {
         this._mediaServerPlayer.LoopStatus = loopStatus;
       }
-    },
+    }
 
     get shouldShowLoopStatus() {
       return this._mediaServerPlayer.LoopStatus !== null && this._mediaServerPlayer.Shuffle !== null;
-    },
+    }
 
     get playbackStatus() {
       return this._mediaServerPlayer.PlaybackStatus || Settings.Status.STOP;
-    },
+    }
 
     get identity() {
       return this._mediaServer.Identity || this._identity;
-    },
+    }
 
     get desktopEntry() {
       return (this._mediaServer.DesktopEntry || '');
-    },
+    }
 
     get activePlaylist() {
       let activePlaylist = this._mediaServerPlaylists.ActivePlaylist;
@@ -758,116 +756,116 @@ var MPRISPlayer = new Lang.Class({
       }
       else {
         activePlaylist = activePlaylist[1];
-      }      
+      }
       return activePlaylist;
-    },
+    }
 
     get playlistCount() {
       return this._mediaServerPlaylists.PlaylistCount || 0;
-    },
+    }
 
     get orderings() {
       return this._checkOrderings(this._mediaServerPlaylists.Orderings);
-    },
+    }
 
     get showPlayStatusIcon() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_PLAY_STATUS_ICON_KEY);
-    },
+    }
 
     get showLoopStatus() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_LOOP_STATUS_KEY) && this.shouldShowLoopStatus && !this.noLoopStatusSupport;
-    },
+    }
 
     get showStopButton() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_STOP_BUTTON_KEY) && !this.playerIsBroken;
-    },
+    }
 
     get buttonIconStyle() {
       return this._settings.get_enum(Settings.MEDIAPLAYER_BUTTON_ICON_STYLE_KEY);
-    },
+    }
 
     get showVolume() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_VOLUME_KEY) && !this.playerIsBroken;
-    },
+    }
 
     get showPosition() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_POSITION_KEY) && !this.playerIsBroken;
-    },
+    }
 
     get showRating() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_RATING_KEY) && !this.playerIsBroken;
-    },
+    }
 
     get showPlaylist() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_PLAYLISTS_KEY) && !this.playerIsBroken && !this.isClementine;
-    },
+    }
 
     get showPlaylistTitle() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_PLAYLIST_TITLE_KEY) && !this.playerIsBroken && !this.isClementine;
-    },
+    }
 
     get showTracklist() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_TRACKLIST_KEY) && !this.playerIsBroken && !this.isClementine;
-    },
+    }
 
     get showTracklistRating() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_TRACKLIST_RATING_KEY) && !this.playerIsBroken;
-    },
+    }
 
     get hideStockMpris() {
       return this._settings.get_boolean(Settings.MEDIAPLAYER_HIDE_STOCK_MPRIS_KEY);
-    },
+    }
 
-    next: function() {
+    next() {
       this._mediaServerPlayer.NextRemote();
-    },
+    }
 
-    previous: function() {
+    previous() {
       this._mediaServerPlayer.PreviousRemote();
-    },
+    }
 
-    playPause: function() {
+    playPause() {
       this._mediaServerPlayer.PlayPauseRemote();
-    },
+    }
 
-    stop: function() {
+    stop() {
       this._mediaServerPlayer.StopRemote();
-    },
+    }
 
-    seek: function(value) {
+    seek(value) {
       let time = value * this.state.trackLength;
       this._wantedSeekValue = Math.round(time * 1000000);
       this._mediaServerPlayer.SetPositionRemote(this.state.trackObj, this._wantedSeekValue);
-    },
+    }
 
-    playPlaylist: function(playlistObj) {
+    playPlaylist(playlistObj) {
       this._mediaServerPlaylists.ActivatePlaylistRemote(playlistObj);
-    },
+    }
 
-    playTrack: function(track) {
+    playTrack(track) {
       // GNOME Music crashes if you call the GoTo method.
       //https://bugzilla.gnome.org/show_bug.cgi?id=779052
       if (this.busName !== 'org.mpris.MediaPlayer2.GnomeMusic') {
         this._mediaServerTracklist.GoToRemote(track);
       }
-    },
+    }
 
-    raise: function() {
+    raise() {
       if (this.app) {
         this.app.activate_full(-1, 0);
       }
       else if (this._mediaServer.CanRaise) {
         this._mediaServer.RaiseRemote();
       }
-    },
+    }
 
-    quit: function() {
+    quit() {
       if (this.canQuit) {
         this._mediaServer.QuitRemote();
       }
-    },
+    }
 
-    _refreshProperties: function(newState) {
+    _refreshProperties(newState) {
       // Check properties
       // Many players have a habit of changing properties without emitting
       // a PropertiesChanged signal as they should. This is basically CYA.
@@ -899,7 +897,7 @@ var MPRISPlayer = new Lang.Class({
                     newState.canPause = canPause;
                     newState.emitSignal = true;
                   }
-                }                             
+                }
                 if (newState.canGoNext === null && props.CanGoNext) {
                 let canGoNext = props.CanGoNext.unpack();
                   if (this.state.canGoNext !== canGoNext) {
@@ -985,9 +983,9 @@ var MPRISPlayer = new Lang.Class({
               }
           }));
       }));
-    },
+    }
 
-    _getPlaylists: function(orderings) {
+    _getPlaylists(orderings) {
       // A player may have trigger the fetching of a playlist
       // before our initial startup timeout happens.
       if (this._playlistTimeOutId !== 0) {
@@ -1007,14 +1005,14 @@ var MPRISPlayer = new Lang.Class({
             this.emit('update-player-state', new PlayerState({showPlaylist: true}));
           }
           this.emit('update-player-state', new PlayerState({playlists: playlists}));
-        } 
+        }
         else {
           this.emit('update-player-state', new PlayerState({showPlaylist: false}));
         }
       }));
-    },
+    }
 
-    _getTracklist: function() {
+    _getTracklist() {
       // A player may have trigger the fetching of a tracklist
       // before our initial startup timeout happens.
       if (this._tracklistTimeOutId !== 0) {
@@ -1038,9 +1036,9 @@ var MPRISPlayer = new Lang.Class({
           }
         }));
       }
-    },
+    }
 
-    _onStatusChange: function(newState) {
+    _onStatusChange(newState) {
       // If the player is broken (Spotify you suck...) we'll never see the
       // position slider any way. No need to waste CPU cycles
       // on a timer...
@@ -1049,7 +1047,7 @@ var MPRISPlayer = new Lang.Class({
       }
       // sync track time
       // If the time is fresh we just came from a
-      // properties refresh and don't need to do it again. 
+      // properties refresh and don't need to do it again.
       if (!newState.timeFresh) {
         let newState = new PlayerState();
         this._refreshProperties(newState);
@@ -1064,24 +1062,24 @@ var MPRISPlayer = new Lang.Class({
         this._stopTimer();
         this.trackTime = 0;
       }
-    },
+    }
 
-    _startTimer: function() {
+    _startTimer() {
       if (this._timerId === 0) {
         this._timerId = Mainloop.timeout_add_seconds(1, Lang.bind(this, function() {
           return this.trackTime += 1;
         }));
       }
-    },
+    }
 
-    _stopTimer: function() {
+    _stopTimer() {
       if (this._timerId !== 0) {
         Mainloop.source_remove(this._timerId);
         this._timerId = 0;
       }
-    },
+    }
 
-    _formatTime: function(s) {
+    _formatTime(s) {
       if (Number.isNaN(s) || s < 0) {
         return '0:00'
       }
@@ -1092,9 +1090,9 @@ var MPRISPlayer = new Lang.Class({
       m = m < 10 && h > 0 ? '0' + m + ':' : m + ':';
       h = h > 0 ? h + ':' : '';
       return h + m + s;
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         // Cancel all pending timeouts.
         this._stopTimer();
         if (this._playlistTimeOutId !== 0) {
@@ -1125,10 +1123,10 @@ var MPRISPlayer = new Lang.Class({
         for (let id in this._signalsId) {
             this._settings.disconnect(this._signalsId[id]);
         }
-    },
+    }
 
-    toString: function() {
+    toString() {
         return "<object MPRISPlayer(%s)>".format(this.info.identity);
     }
-});
+};
 Signals.addSignalMethods(MPRISPlayer.prototype);

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -33,14 +33,14 @@ const Gsettings = Lib.getSettings(Me);
 const GNU_SOFTWARE = '<span size="small">' +
     'This program comes with absolutely no warranty.\n' +
     'See the <a href="https://gnu.org/licenses/old-licenses/gpl-2.0.html">' +
-	'GNU General Public License, version 2 or later</a> for details.' +
-	'</span>';
+    'GNU General Public License, version 2 or later</a> for details.' +
+    '</span>';
 
 const CC_BY_SA = '<span size="small">' +
     'All artwork released under the Creative Commons Attribution-ShareAlike 4.0 International license.\n' +
     'See the <a href="https://creativecommons.org/licenses/by-sa/4.0/legalcode">' +
-	'CC BY-SA 4.0</a> for details.' +
-	'</span>';
+    'CC BY-SA 4.0</a> for details.' +
+    '</span>';
 
 const Creators = [
     {label: 'Jonas Wielicki',
@@ -54,21 +54,21 @@ const Creators = [
     {label: 'Bilal Elmoussaoui',
      url: 'https://github.com/bil-elmoussaoui'},
     {label: 'Alexander Rüedlinger',
-     url: 'https://github.com/lexruee'}    
+     url: 'https://github.com/lexruee'}
 ];
 
 const Artists = [
     {label: 'LinxGem33',
      url: 'https://github.com/LinxGem33'},
     {label: 'Jason Gray',
-     url: 'https://github.com/JasonLG1979'}     
+     url: 'https://github.com/JasonLG1979'}
 ];
 
 const Documenters = [
     {label: 'Jean-Philippe Braun',
      url: 'https://github.com/eonpatapon'},
     {label: 'Jason Gray',
-     url: 'https://github.com/JasonLG1979'}     
+     url: 'https://github.com/JasonLG1979'}
 ];
 
 
@@ -203,13 +203,10 @@ const Settings = {
     },
 };
 
-const Frame = new GObject.Class({
-    Name: 'Frame',
-    GTypeName: 'Frame',
-    Extends: Gtk.Box,
+const Frame = GObject.registerClass(class Frame extends Gtk.Box {
 
-    _init: function(title) {
-        this.parent({
+    _init(title) {
+        super._init({
             orientation: Gtk.Orientation.VERTICAL,
             margin_bottom: 6,
             margin_start: 6,
@@ -220,13 +217,10 @@ const Frame = new GObject.Class({
     }
 });
 
-const Notebook = new GObject.Class({
-    Name: 'Notebook',
-    GTypeName: 'Notebook',
-    Extends: Gtk.Notebook,
+const Notebook = GObject.registerClass(class Notebook extends Gtk.Notebook {
 
-    _init: function() {
-        this.parent({
+    _init() {
+        super._init({
             margin_top: 6,
             margin_bottom: 6,
             margin_start: 6,
@@ -234,9 +228,9 @@ const Notebook = new GObject.Class({
             hexpand: true,
             vexpand: true
         });
-    },
+    }
 
-    append_page: function(notebookPage) {
+    append_page(notebookPage) {
         Gtk.Notebook.prototype.append_page.call(
             this,
             notebookPage,
@@ -245,26 +239,23 @@ const Notebook = new GObject.Class({
     }
 });
 
-const NotebookPage = new GObject.Class({
-    Name: 'NotebookPage',
-    GTypeName: 'NotebookPage',
-    Extends: Gtk.Box,
+const NotebookPage = GObject.registerClass(class NotebookPage extends Gtk.Box {
 
-    _init: function(title) {
-        this.parent({
+    _init(title) {
+        super._init({
             orientation: Gtk.Orientation.VERTICAL,
             homogeneous: false
         });
         this._title = new Gtk.Label({
             label: title,
         });
-    },
+    }
 
-    getTitleLabel: function() {
+    getTitleLabel() {
         return this._title;
-    },
+    }
 
-    addSettingsBox: function(settingsBox) {
+    addSettingsBox(settingsBox) {
         this.pack_start(settingsBox, false, false, 0);
         let sep = new Gtk.Separator({
             orientation: Gtk.Orientation.HORIZONTAL,
@@ -275,13 +266,10 @@ const NotebookPage = new GObject.Class({
     }
 });
 
-const SettingsLabel = new GObject.Class({
-    Name: 'SettingsLabel',
-    GTypeName: 'SettingsLabel',
-    Extends: Gtk.Label,
+const SettingsLabel = GObject.registerClass(class SettingsLabel extends Gtk.Label {
 
-    _init: function(label) {
-        this.parent({
+    _init(label) {
+        super._init({
             label: label,
             valign: Gtk.Align.CENTER,
             halign: Gtk.Align.START
@@ -289,13 +277,10 @@ const SettingsLabel = new GObject.Class({
     }
 });
 
-const SettingsBox = new GObject.Class({
-    Name: 'SettingsBox',
-    GTypeName: 'SettingsBox',
-    Extends: Gtk.Box,
+const SettingsBox = GObject.registerClass(class SettingsBox extends Gtk.Box {
 
-    _init: function(setting) {
-        this.parent({
+    _init(setting) {
+        super._init({
             orientation: Gtk.Orientation.HORIZONTAL,
             margin_top: 6,
             margin_bottom: 6,
@@ -310,7 +295,7 @@ const SettingsBox = new GObject.Class({
         if (toolTip) {
             this.set_tooltip_text(toolTip);
         }
-        
+
         let widget;
 
         if (Settings[setting].type == 's') {
@@ -331,15 +316,12 @@ const SettingsBox = new GObject.Class({
     }
 });
 
-const SettingsSwitch = new GObject.Class({
-    Name: 'SettingsSwitch',
-    GTypeName: 'SettingsSwitch',
-    Extends: Gtk.Switch,
+const SettingsSwitch = GObject.registerClass(class SettingsSwitch extends Gtk.Switch {
 
-    _init: function(setting) {
+    _init(setting) {
         let active = Gsettings.get_boolean(setting);
 
-        this.parent({
+        super._init({
             valign: Gtk.Align.CENTER,
             halign: Gtk.Align.END,
             active: active
@@ -354,13 +336,10 @@ const SettingsSwitch = new GObject.Class({
     }
 });
 
-const SettingsCombo = new GObject.Class({
-    Name: 'SettingsCombo',
-    GTypeName: 'SettingsCombo',
-    Extends: Gtk.ComboBoxText,
+const SettingsCombo = GObject.registerClass(class SettingsCombo extends Gtk.ComboBoxText {
 
-    _init: function(setting) {
-        this.parent({
+    _init(setting) {
+        super._init({
             valign: Gtk.Align.CENTER,
             halign: Gtk.Align.END
         });
@@ -381,15 +360,12 @@ const SettingsCombo = new GObject.Class({
     }
 });
 
-const SettingsEntry = new GObject.Class({
-    Name: 'SettingsEntry',
-    GTypeName: 'SettingsEntry',
-    Extends: Gtk.Entry,
+const SettingsEntry = GObject.registerClass(class SettingsEntry extends Gtk.Entry {
 
-    _init: function(setting) {
+    _init(setting) {
         let text = Gsettings.get_string(setting);
 
-        this.parent({
+        super._init({
             valign: Gtk.Align.CENTER,
             halign: Gtk.Align.END,
             width_chars: 30,
@@ -411,12 +387,9 @@ const SettingsEntry = new GObject.Class({
     }
 });
 
-const SettingsSpinButton = new GObject.Class({
-    Name: 'SettingsSpinButton',
-    GTypeName: 'SettingsSpinButton',
-    Extends: Gtk.SpinButton,
+const SettingsSpinButton = GObject.registerClass(class SettingsSpinButton extends Gtk.SpinButton {
 
-    _init: function(setting) {
+    _init(setting) {
         let adjustment = new Gtk.Adjustment({
             lower: Settings[setting].min,
             upper: Settings[setting].max,
@@ -425,7 +398,7 @@ const SettingsSpinButton = new GObject.Class({
 
         let value = Gsettings.get_int(setting);
 
-        this.parent({
+        super._init({
             valign: Gtk.Align.CENTER,
             halign: Gtk.Align.END,
             climb_rate: 1.0,
@@ -443,13 +416,10 @@ const SettingsSpinButton = new GObject.Class({
     }
 });
 
-const CreditBox = new GObject.Class({
-    Name: 'CreditBox',
-    GTypeName: 'CreditBox',
-    Extends: Gtk.Box,
+const CreditBox = GObject.registerClass(class CreditBox extends Gtk.Box {
 
-    _init: function() {
-        this.parent({
+    _init() {
+        super._init({
             orientation: Gtk.Orientation.VERTICAL,
             margin_top: 6,
             margin_bottom: 6,
@@ -579,16 +549,13 @@ const CreditBox = new GObject.Class({
         viewPort.add(innerCreditBox);
         scrolledWindow.add(viewPort);
         this.add(scrolledWindow);
-            
     }
 });
 
-const AboutPage = new Lang.Class({
-    Name: 'AboutPage',
-    Extends: NotebookPage,
+const AboutPage = GObject.registerClass(class AboutPage extends NotebookPage {
 
-    _init: function(settings) {
-        this.parent(_('About'));
+    _init(settings) {
+        super._init(_('About'));
         let releaseVersion = Me.metadata['version'] ? _('Version ') + Me.metadata['version'] : 'git-master';
         let projectName = Me.metadata['name'];
         let projectDescription = Me.metadata['description'];
@@ -675,13 +642,10 @@ const AboutPage = new Lang.Class({
     }
 });
 
-const PrefsWidget = new GObject.Class({
-    Name: 'PrefsWidget',
-    GTypeName: 'PrefsWidget',
-    Extends: Frame,
+const PrefsWidget = GObject.registerClass(class PrefsWidget extends Frame {
 
-    _init: function() {
-        this.parent();
+    _init() {
+        super._init();
         this._notebook = new Notebook();
 
         this._indicatorPage = new NotebookPage(_("Indicator"));
@@ -699,7 +663,7 @@ const PrefsWidget = new GObject.Class({
 
         let settingsBox;
 
-        for (let setting in Settings) { 
+        for (let setting in Settings) {
             settingsBox = new SettingsBox(setting);
 
             if (Gtk.get_minor_version() < 20 && setting == "hide-stockmpris") {
@@ -717,11 +681,11 @@ const PrefsWidget = new GObject.Class({
             }
         }
     }
-});    
+});
 
 function init() {
     Lib.initTranslations(Me);
-    Lib.addIcon(Me); 
+    Lib.addIcon(Me);
 }
 
 function buildPrefsWidget() {

--- a/src/ui.js
+++ b/src/ui.js
@@ -35,12 +35,10 @@ const Settings = Me.imports.settings;
 const Util = Me.imports.util;
 
 
-var PlayerUI = new Lang.Class({
-  Name: 'PlayerUI',
-  Extends: Widget.PlayerMenu,
+var PlayerUI = class PlayerUI extends Widget.PlayerMenu {
 
-  _init: function(player) {
-    this.parent('', true);
+  constructor(player) {
+    super('', true);
     this.hidePlayStatusIcon();
     this.player = player;
     this.setCoverIconAsync = Util.setCoverIconAsync;
@@ -66,7 +64,7 @@ var PlayerUI = new Lang.Class({
     this.info = new Widget.Info();
     this.info.connect('activate', Lang.bind(this.player, this.player.raise));
     this.addMenuItem(this.info);
-        
+
     this.trackControls = new Widget.PlayerButtons();
     this.trackControls.connect('activate', Lang.bind(this.player, this.player.raise));
 
@@ -81,7 +79,7 @@ var PlayerUI = new Lang.Class({
     this.stopButton = new Widget.PlayerButton('media-playback-stop-symbolic',
                                               Lang.bind(this.player, this.player.stop));
     this.trackControls.addButton(this.stopButton);
-    
+
     this.nextButton = new Widget.PlayerButton('media-skip-forward-symbolic',
                                               Lang.bind(this.player, this.player.next));
     this.trackControls.addButton(this.nextButton);
@@ -114,7 +112,7 @@ var PlayerUI = new Lang.Class({
     this.tracklist = this._createTracklistWidget();
     this.addMenuItem(this.tracklist);
     this.tracklist.hide();
- 
+
     this.playlists = this._createPlaylistWidget();
     this.addMenuItem(this.playlists);
     this.playlists.hide();
@@ -134,15 +132,15 @@ var PlayerUI = new Lang.Class({
       this.stockMpris = Main.panel.statusArea.dateMenu._messageList._mediaSection;
       //Monkey patch
       this.stockMprisOldShouldShow = this.stockMpris._shouldShow;
-      
-    } 
-  },
+
+    }
+  }
 
   get state() {
     return this.player.state;
-  },
+  }
 
-  update: function(player, newState) {
+  update(player, newState) {
     if (newState.desktopEntry !== null) {
       this.icon.icon_name = Util.getPlayerSymbolicIcon(this.state.desktopEntry);
     }
@@ -177,7 +175,7 @@ var PlayerUI = new Lang.Class({
           && !this.state.isRhythmboxStream
           && this.state.status !== Settings.Status.STOP) {
         this.shuffleLoopStatus.showAnimate();
-      }             
+      }
     }
 
     if (newState.showPlayStatusIcon !== null) {
@@ -186,7 +184,7 @@ var PlayerUI = new Lang.Class({
       }
       else {
         this.hidePlayStatusIcon();
-      }              
+      }
     }
 
     if (newState.showRating !== null) {
@@ -198,7 +196,7 @@ var PlayerUI = new Lang.Class({
       }
       else {
         this.trackRatings.hideAnimate();
-      }              
+      }
     }
 
     if (newState.showVolume !== null) {
@@ -336,7 +334,7 @@ var PlayerUI = new Lang.Class({
           volumeIcon = 'audio-volume-low-symbolic';
         }
         else if (n >= 3) {
-          volumeIcon = 'audio-volume-high-symbolic';          
+          volumeIcon = 'audio-volume-high-symbolic';
         }
         else {
           volumeIcon = 'audio-volume-medium-symbolic';
@@ -468,8 +466,8 @@ var PlayerUI = new Lang.Class({
         }
         else {
            this.playButton.disable();
-        }                 
-      }      
+        }
+      }
       if (this.state.status === Settings.Status.STOP) {
         this.setPlayStatusIcon('media-playback-stop-symbolic');
         this.stopButton.hide();
@@ -513,7 +511,7 @@ var PlayerUI = new Lang.Class({
     if (newState.showStopButton !== null) {
       if (this.state.showStopButton && this.state.status !== Settings.Status.STOP) {
         this.stopButton.show();
-      }       
+      }
       else if (this.state.status === Settings.Status.PLAY && this.state.canPause) {
         this.stopButton.hide();
       }
@@ -561,9 +559,9 @@ var PlayerUI = new Lang.Class({
     if (newState.updatedMetadata !== null) {
       this.tracklist.updateMetadata(this.state.updatedMetadata);
     }
-  },
+  }
 
-  _createPlaylistWidget: function() {
+  _createPlaylistWidget() {
     let playlistTitle = _("Playlists");
     let altPlaylistTitles = Settings.ALTERNATIVE_PLAYLIST_TITLES;
     for (let i = 0; i < altPlaylistTitles.length; i++) {
@@ -576,9 +574,9 @@ var PlayerUI = new Lang.Class({
       }
     }
     return new Widget.Playlists(playlistTitle, this.player);
-  },
+  }
 
-  _createTracklistWidget: function() {
+  _createTracklistWidget() {
     let tracklistTitle = _("Tracks");
     let altTracklistTitles = Settings.ALTERNATIVE_TRACKLIST_TITLES;
     for (let i = 0; i < altTracklistTitles.length; i++) {
@@ -591,18 +589,16 @@ var PlayerUI = new Lang.Class({
       }
     }
     return new Widget.TrackList(tracklistTitle, this.player);
-  },
+  }
 
-  toString: function() {
+  toString() {
       return '[object PlayerUI(%s)]'.format(this.player.busName);
-  },
+  }
 
-
-  destroy: function() {
+  destroy() {
     if (this._updateId) {
       this.player.disconnect(this._updateId);
     }
-    this.parent();
+    super.destroy();
   }
-
-});
+};

--- a/src/widget.js
+++ b/src/widget.js
@@ -41,12 +41,10 @@ const Util = Me.imports.util;
 const DBusIface = Me.imports.dbus;
 
 
-var SubMenu = new Lang.Class({
-    Name: 'SubMenu',
-    Extends: PopupMenu.PopupMenuBase,
+var SubMenu = class SubMenu extends PopupMenu.PopupMenuBase {
 
-    _init: function(sourceActor, sourceArrow, isPlayerMenu) {
-        this.parent(sourceActor);
+    constructor(sourceActor, sourceArrow, isPlayerMenu) {
+        super(sourceActor);
         this._isPlayerMenu = isPlayerMenu;
         this._arrow = sourceArrow;
 
@@ -59,22 +57,22 @@ var SubMenu = new Lang.Class({
         this.actor.clip_to_allocation = true;
         this.actor.connect('key-press-event', Lang.bind(this, this._onKeyPressEvent));
         this.actor.hide();
-    },
+    }
 
-    _needsScrollbar: function() {
+    _needsScrollbar() {
         let topMenu = this._getTopMenu();
         let [topMinHeight, topNaturalHeight] = topMenu.actor.get_preferred_height(-1);
         let topThemeNode = topMenu.actor.get_theme_node();
 
         let topMaxHeight = topThemeNode.get_max_height();
         return topMaxHeight >= 0 && topNaturalHeight >= topMaxHeight;
-    },
+    }
 
-    getSensitive: function() {
+    getSensitive() {
         return this._sensitive && this.sourceActor._delegate.getSensitive();
-    },
+    }
 
-    open: function() {
+    open() {
         if (this.isOpen || this.isEmpty())
             return;
 
@@ -93,9 +91,9 @@ var SubMenu = new Lang.Class({
         }
 
         this._arrow.rotation_angle_z = this.actor.text_direction == Clutter.TextDirection.RTL ? -90 : 90;
-    },
+    }
 
-    close: function() {
+    close() {
         if (!this.isOpen || this.isEmpty())
             return;
 
@@ -106,9 +104,9 @@ var SubMenu = new Lang.Class({
             this._activeMenuItem.setActive(false);
         this._arrow.rotation_angle_z = 0;
         this.actor.hide();
-    },
+    }
 
-    _onKeyPressEvent: function(actor, event) {
+    _onKeyPressEvent(actor, event) {
         // Move focus back to parent menu if the user types Left.
 
         if (this.isOpen && event.get_key_symbol() == Clutter.KEY_Left) {
@@ -119,43 +117,39 @@ var SubMenu = new Lang.Class({
 
         return Clutter.EVENT_PROPAGATE;
     }
-});
+};
 
-var PlayerMenu = new Lang.Class({
-  Name: 'PlayerMenu',
-  Extends: PopupMenu.PopupSubMenuMenuItem,
+var PlayerMenu = class PlayerMenu extends PopupMenu.PopupSubMenuMenuItem {
 
-  _init: function(label, wantIcon) {
-    this.parent(label, wantIcon);
+  constructor(label, wantIcon) {
+    super(label, wantIcon);
     this._playStatusIcon = new St.Icon({style_class: 'popup-menu-icon'});
     this.actor.insert_child_at_index(this._playStatusIcon, 3);
     this.menu = new SubMenu(this.actor, this._triangle, true);
     this.menu.connect('open-state-changed', Lang.bind(this, this._subMenuOpenStateChanged));
-  },
+  }
 
-  addMenuItem: function(item) {
+  addMenuItem(item) {
     this.menu.addMenuItem(item);
-  },
+  }
 
-  setPlayStatusIcon: function(icon) {
+  setPlayStatusIcon(icon) {
     this._playStatusIcon.icon_name = icon;
-  },
+  }
 
-  hidePlayStatusIcon: function() {
+  hidePlayStatusIcon() {
     this._playStatusIcon.hide();
-  },
+  }
 
-  showPlayStatusIcon: function() {
+  showPlayStatusIcon() {
     this._playStatusIcon.show();
   }
-});
+};
 
-var BaseContainer = new Lang.Class({
-    Name: "BaseContainer",
-    Extends: PopupMenu.PopupBaseMenuItem,
+var BaseContainer = class BaseContainer extends PopupMenu.PopupBaseMenuItem {
 
-    _init: function(parms) {
-      this.parent(parms);
+    constructor(parms) {
+      super(parms);
       this._hidden = false;
       this._animating = false;
       //We don't want our BaseContainers to be highlighted when clicked,
@@ -163,39 +157,39 @@ var BaseContainer = new Lang.Class({
       //We want to maintain the illusion that they are normal UI containers,
       //and that our main track UI area is one big container.
       this.actor.add_style_pseudo_class = function() {return null;};
-    },
+    }
 
     get hidden() {
       return this._hidden;
-    },
+    }
 
     set hidden(value) {
       this._hidden = value;
-    },
+    }
 
     get animating() {
       return this._animating;
-    },
+    }
 
     set animating(value) {
       this._animating = value;
-    },
+    }
 
-    hide: function() {
+    hide() {
       this.actor.hide();
       this.actor.opacity = 0;
       this.actor.set_height(0);
       this.hidden = true;
-    },
+    }
 
-    show: function() {
+    show() {
       this.actor.show();
       this.actor.opacity = 255;
       this.actor.set_height(-1);
       this.hidden = false;
-    },
+    }
 
-    showAnimate: function() {
+    showAnimate() {
       if (!this.actor.get_stage() || !this._hidden || this.animating) {
         return;
       }
@@ -214,9 +208,9 @@ var BaseContainer = new Lang.Class({
         },
         onCompleteScope: this
       });
-    },
+    }
 
-    hideAnimate: function() {
+    hideAnimate() {
       if (!this.actor.get_stage() || this._hidden || this.animating) {
         return;
       }
@@ -232,38 +226,33 @@ var BaseContainer = new Lang.Class({
         onCompleteScope: this
       });
     }
-});
+};
 
-var CenteredBaseContainer = new Lang.Class({
-    Name: "CenteredBaseContainer",
-    Extends: BaseContainer,
+var CenteredBaseContainer = class CenteredBaseContainer extends BaseContainer {
 
-    _init: function(parms) {
-      this.parent(parms);
+    constructor(parms) {
+      super(parms);
       this.actor.add_style_class_name('album-details');
-    },
-});
+    }
+};
 
-var PlayerButtons = new Lang.Class({
-    Name: 'PlayerButtons',
-    Extends: CenteredBaseContainer,
+var PlayerButtons = class PlayerButtons extends CenteredBaseContainer {
 
-    _init: function() {
-        this.parent({hover: false});
+    constructor() {
+        super({hover: false});
         this.box = new St.BoxLayout({style_class: 'no-padding-bottom player-buttons'});
         this.actor.add(this.box, {expand: true, x_fill: false, x_align: St.Align.MIDDLE});
-    },
-    addButton: function(button) {
+    }
+
+    addButton(button) {
         this.box.add(button.actor, {expand: false});
     }
-});
+};
 
-var ShuffleLoopStatus = new Lang.Class({
-    Name: 'PlayerButtons',
-    Extends: BaseContainer,
+var ShuffleLoopStatus = class PlayerButtons extends BaseContainer {
 
-    _init: function(player) {
-        this.parent({hover: false});
+    constructor(player) {
+        super({hover: false});
         this._player = player;
         this.box = new St.BoxLayout({style_class: 'no-padding-bottom no-padding-top'});
         this.actor.add(this.box, {expand: true, x_fill: false, x_align: St.Align.MIDDLE});
@@ -291,9 +280,9 @@ var ShuffleLoopStatus = new Lang.Class({
           this._player.loopStatus = this._player.state.loopStatus == 'Playlist' ? 'None' : 'Playlist';
         }));
         this.box.add(this._repeatAllButton);
-    },
+    }
 
-    setLoopStaus: function (loopStatus) {
+    setLoopStaus(loopStatus) {
       if (loopStatus == 'None') {
         this._setButtonActive(this._repeatButton, false);
         this._setButtonActive(this._repeatAllButton, false);
@@ -306,43 +295,40 @@ var ShuffleLoopStatus = new Lang.Class({
         this._setButtonActive(this._repeatButton, false);
         this._setButtonActive(this._repeatAllButton, true);
       }
-    },
+    }
 
-    setShuffle: function (shuffle) {
+    setShuffle(shuffle) {
       this._setButtonActive(this._shuffleButton, shuffle);
-    },
+    }
 
-    _setButtonActive: function (button, active) {
+    _setButtonActive(button, active) {
       button._isActive = active;
       button.opacity = active ? 204 : 102;
-    },
+    }
 
-    _onButtonHover: function (button) {
+    _onButtonHover(button) {
       button.opacity = button.hover ? 255 : button._isActive ? 204 : 102;
     }
-});
+};
 
-var PlaylistTitle = new Lang.Class({
-    Name: 'PlaylistTitle',
-    Extends: CenteredBaseContainer,
+var PlaylistTitle = class PlaylistTitle extends CenteredBaseContainer {
 
-    _init: function () {
-        this.parent({hover: false, style_class: 'no-padding-bottom'});
+    constructor() {
+        super({hover: false, style_class: 'no-padding-bottom'});
         this._label = new St.Label({style_class: 'track-info-artist'});
         this.actor.add(this._label, {expand: true, x_fill: false, x_align: St.Align.MIDDLE});
-    },
+    }
 
-    update: function(name) {
+    update(name) {
       if (name && this._label.text != name) {
         this._label.text = name;
       }
     }
-});
+};
 
-var PlayerButton = new Lang.Class({
-    Name: "PlayerButton",
+var PlayerButton = class PlayerButton {
 
-    _init: function(icon, callback) {
+    constructor(icon, callback) {
         this.actor = new St.Button({child: new St.Icon({icon_name: icon})});
         this.actor.opacity = 204;
         this.actor._delegate = this;
@@ -350,13 +336,13 @@ var PlayerButton = new Lang.Class({
         this.actor.connect('notify::hover', Lang.bind(this, function(button) {
           this.actor.opacity = button.hover ? 255 : 204;
         }));
-    },
+    }
 
-    setIcon: function(icon) {
+    setIcon(icon) {
         this.actor.child.icon_name = icon;
-    },
+    }
 
-    setIconSize: function(style) {
+    setIconSize(style) {
         if (style == Settings.ButtonIconStyles.CIRCULAR) {
           this.actor.child.style_class = null;
           this.actor.style_class = 'system-menu-action';
@@ -373,75 +359,70 @@ var PlayerButton = new Lang.Class({
           this.actor.style_class = null;
           this.actor.child.style_class = 'shell-mount-operation-icon large-player-button';
         }
-    },
+    }
 
-    enable: function() {
+    enable() {
         this.actor.reactive = true;
         this.actor.opacity = 204;
-    },
+    }
 
-    disable: function() {
+    disable() {
         this.actor.reactive = false;
         this.actor.opacity = 102;
-    },
+    }
 
-    hide: function() {
+    hide() {
       this.actor.hide();
-    },
+    }
 
-    show: function() {
+    show() {
       this.actor.show();
     }
-});
+};
 
-var SliderItem = new Lang.Class({
-    Name: "SliderItem",
-    Extends: CenteredBaseContainer,
+var SliderItem = class SliderItem extends CenteredBaseContainer {
 
-    _init: function(icon) {
-        this.parent({hover: false});
+    constructor(icon) {
+        super({hover: false});
         this._icon = new St.Icon({style_class: 'popup-menu-icon', icon_name: icon});
         this._slider = new Slider.Slider(0);
         this.actor.add_style_class_name('slider-row');
+
         this.actor.add(this._icon);
         this.actor.add(this._slider.actor, {expand: true});
-    },
+    }
 
-    setReactive: function(reactive) {
+    setReactive(reactive) {
         this._slider.actor.reactive = reactive;
-    },
+    }
 
-    setValue: function(value) {
+    setValue(value) {
         this._slider.setValue(value);
-    },
+    }
 
-    setIcon: function(icon) {
+    setIcon(icon) {
         this._icon.icon_name = icon;
-    },
+    }
 
-    sliderConnect: function(signal, callback) {
+    sliderConnect(signal, callback) {
         this._slider.connect(signal, callback);
     }
-});
+};
 
-var TrackCover = new Lang.Class({
-    Name: "TrackBox",
-    Extends: CenteredBaseContainer,
+var TrackCover = class TrackBox extends CenteredBaseContainer {
 
-    _init: function(icon) {
-      this.parent({hover: false, style_class: 'no-padding-bottom'});
+    constructor(icon) {
+      super({hover: false, style_class: 'no-padding-bottom'});
       this.icon = icon;
       this.actor.add(this.icon, {expand: true, x_fill: false, x_align: St.Align.MIDDLE});
     }
-});
+};
 
-var Info = new Lang.Class({
-    Name: "SecondaryInfo",
-    Extends: CenteredBaseContainer,
+var Info = class SecondaryInfo extends CenteredBaseContainer {
 
-    _init: function() {
-      this.parent({hover: false, style_class: 'no-padding-bottom'});
-      this._animateChange = Util.animateChange;     
+    constructor() {
+      super({hover: false, style_class: 'no-padding-bottom'});
+      this._animateChange = Util.animateChange;
       this.infos = new St.BoxLayout({vertical: true});
       this._artistLabel = new St.Label({style_class: 'track-info-artist'});
       this._titleLabel = new St.Label({style_class: 'track-info-title'});
@@ -450,15 +431,15 @@ var Info = new Lang.Class({
       this.infos.add(this._titleLabel, {expand: true, x_fill: false, x_align: St.Align.MIDDLE});
       this.infos.add(this._albumLabel, {expand: true, x_fill: false, x_align: St.Align.MIDDLE});
       this.actor.add(this.infos, {expand: true, x_fill: false, x_align: St.Align.MIDDLE});
-    },
+    }
 
-    update: function(state) {
+    update(state) {
       this._setInfoText(this._artistLabel, state.trackArtist);
       this._setInfoText(this._titleLabel, state.trackTitle);
       this._setInfoText(this._albumLabel, state.trackAlbum);
-    },
+    }
 
-    _setInfoText: function(actor, text) {
+    _setInfoText(actor, text) {
       if (text) {
         if (actor.text != text) {
           this._showAnimateInfoItem(actor, text);
@@ -467,21 +448,21 @@ var Info = new Lang.Class({
       else {
         this._hideAnimateInfoItem(actor, text);
       }
-    },
+    }
 
-    _hideInfoItem: function(actor) {
+    _hideInfoItem(actor) {
       actor.hide();
       actor.opacity = 0;
       actor.set_height(0);
-    },
+    }
 
-    _showInfoItem: function(actor) {
+    _showInfoItem(actor) {
       actor.show();
       actor.opacity = 255;
       actor.set_height(-1);
-    },
+    }
 
-    _showAnimateInfoItem: function(actor, text) {
+    _showAnimateInfoItem(actor, text) {
       if (actor.visible && !this.animating) {
         this._animateChange(actor, 'text', text);
       }
@@ -505,9 +486,9 @@ var Info = new Lang.Class({
           onCompleteScope: this
         });
       }
-    },
+    }
 
-    _hideAnimateInfoItem: function(actor, text) {
+    _hideAnimateInfoItem(actor, text) {
       if (!actor.visible && !this.animating) {
         actor.text = text;
       }
@@ -528,17 +509,15 @@ var Info = new Lang.Class({
         });
       }
     }
-});
+};
 
-var TrackRating = new Lang.Class({
-    Name: "TrackRating",
-    Extends: CenteredBaseContainer,
+var TrackRating = class TrackRating extends CenteredBaseContainer {
 
-    _init: function(player, value) {
+    constructor(player, value) {
+        super({style_class: 'no-padding-bottom', hover: false});
         this._hidden = false;
         this._player = player;
         this._animateChange = Util.animateChange;
-        this.parent({style_class: 'no-padding-bottom', hover: false});
         this.box = new St.BoxLayout({style_class: 'no-padding track-info-album'});
         this.actor.add(this.box, {expand: true, x_fill: false, x_align: St.Align.MIDDLE});
         this._applyFunc = null;
@@ -574,9 +553,9 @@ var TrackRating = new Lang.Class({
           this.rate = this._rate;
           this._buildStars();
         }
-    },
+    }
 
-    _buildStars: function() {
+    _buildStars() {
         this._starButton = [];
         for(let i=0; i < 5; i++) {
             // Create star icons
@@ -607,9 +586,9 @@ var TrackRating = new Lang.Class({
             // Put the button in the box
             this.box.add(this._starButton[i]);
         }
-    },
+    }
 
-    _buildPithosRatings: function() {
+    _buildPithosRatings() {
         this.box.add_style_class_name('pithos-rating-box');
         this._ratingsIcon = new St.Icon({style_class: 'popup-menu-icon no-padding'});
         this._unRateButton = new St.Button({x_align: St.Align.MIDDLE,
@@ -638,9 +617,9 @@ var TrackRating = new Lang.Class({
         }));
         this._unRateButton.hide();
         this.box.set_width(-1);
-    },
+    }
 
-    _ratePithos: function(rating) {
+    _ratePithos(rating) {
         if (this._value == rating) {
           return;
         }
@@ -668,10 +647,10 @@ var TrackRating = new Lang.Class({
              }));
          }
          this._value = rating;
-         this.box.set_width(-1);      
-    },
+         this.box.set_width(-1);
+    }
 
-    _rate: function(value) {
+    _rate(value) {
         // For Pithos versions without ratings support.
         if (value.constructor === String) {
           value = value == 'love' ? 5 : 0;
@@ -682,7 +661,7 @@ var TrackRating = new Lang.Class({
         if (this._value == value) {
           return;
         }
-        this._value = value;       
+        this._value = value;
         for (let i = 0; i < 5; i++) {
             let icon_name = i < this._value ? 'starred-symbolic' : 'non-starred-symbolic';
             if (this.animating) {
@@ -696,23 +675,23 @@ var TrackRating = new Lang.Class({
               }));
             }
         }
-    },
+    }
 
-    applyQuodLibetRating: function(value) {
+    applyQuodLibetRating(value) {
         // Quod Libet works on 0.0 to 1.0 scores.
         // Quod Libet also does the right thing and emits a prop change signal
         // on ratings changes so we don't have to fake it and set it ourself.
         GLib.spawn_command_line_async("quodlibet --set-rating=%f".format(value / 5.0));
-    },
+    }
 
-    applyLollypopRating: function(value) {
+    applyLollypopRating(value) {
         // Lollypop works on 0 to 5 scores.
         // Lollypop also does the right thing and emits a prop change signal
         // on ratings changes so we don't have to fake it and set it ourself.
         GLib.spawn_command_line_async("lollypop --set-rating=%s".format(value));
-    },
+    }
 
-    applyRhythmbox3Rating: function(value) {
+    applyRhythmbox3Rating(value) {
         if (this._player.state.trackUrl) {
             this._rhythmbox3Proxy.SetEntryPropertiesRemote(this._player.state.trackUrl,
                                                            {rating: GLib.Variant.new_double(value)});
@@ -720,57 +699,55 @@ var TrackRating = new Lang.Class({
           // than likely stick so we just fake it...
           this.rate(value);
         }
-    },
-    
-    applyNuvolaRating: function(value) {
+    }
+
+    applyNuvolaRating(value) {
         if (this.player._mediaServerPlayer.NuvolaCanRate) {
             this.player._mediaServerPlayer.NuvolaSetRatingRemote(value / 5.0);
         }
-    },
+    }
 
-    applyRatingsExtension: function(value) {
+    applyRatingsExtension(value) {
         if (this._player.state.trackObj) {
             this._player._ratingsExtension.SetRatingRemote(this._player.state.trackObj, value / 5.0);
         }
     }
-});
+};
 
-var ListSubMenu = new Lang.Class({
-  Name: 'ListSubMenu',
-  Extends: PopupMenu.PopupSubMenuMenuItem,
+var ListSubMenu = class ListSubMenu extends PopupMenu.PopupSubMenuMenuItem {
 
-  _init: function(label) {
-    this.parent(label, false);
+  constructor(label) {
+    super(label, false);
     this.activeObject = null;
     this._hidden = false;
     this.menu = new SubMenu(this.actor, this._triangle, false);
     this.menu.connect('open-state-changed', Lang.bind(this, this._subMenuOpenStateChanged));
-  },
+  }
 
   get hidden() {
     return this._hidden;
-  },
+  }
 
   set hidden(value) {
     this._hidden = value;
-  },
+  }
 
-  hide: function() {
+  hide() {
     this.menu.close();
     this.actor.hide();
     this.actor.opacity = 0;
     this.actor.set_height(0);
     this.hidden = true;
-  },
+  }
 
-  show: function() {
+  show() {
     this.actor.show();
     this.actor.opacity = 255;
     this.actor.set_height(-1);
     this.hidden = false;
-  }, 
+  }
 
-  showAnimate: function() {
+  showAnimate() {
     if (!this.actor.get_stage() || !this._hidden)
       return;
     this.actor.set_height(-1);
@@ -786,9 +763,9 @@ var ListSubMenu = new Lang.Class({
       },
       onCompleteScope: this
     });
-  },
+  }
 
-  hideAnimate: function() {
+  hideAnimate() {
     if (!this.actor.get_stage() || this._hidden)
       return;
     Tweener.addTween(this.actor, {
@@ -800,9 +777,9 @@ var ListSubMenu = new Lang.Class({
       },
       onCompleteScope: this
     });
-  },
+  }
 
-  setObjectActive: function(objPath) {
+  setObjectActive(objPath) {
     this.activeObject = objPath;
     this.menu._getMenuItems().forEach(function(listItem) {
       if (listItem.obj == objPath) {
@@ -812,11 +789,11 @@ var ListSubMenu = new Lang.Class({
         listItem.setOrnament(PopupMenu.Ornament.NONE);
       }
     });
-  },
-  
-  getItem: function(obj) {        
+  }
+
+  getItem(obj) {
     let menuItems = this.menu._getMenuItems().filter(function(item) {
-        return item.obj === obj;  
+        return item.obj === obj;
     });
     if (menuItems && menuItems[0]) {
       return menuItems[0];
@@ -824,9 +801,9 @@ var ListSubMenu = new Lang.Class({
     else {
       return null;
     }
-  },
+  }
 
-  hasUniqueObjPaths: function(objects, isTracklistMetadata) {
+  hasUniqueObjPaths(objects, isTracklistMetadata) {
     //Check for unique values in the playlist and tracklist object paths.
     let unique = objects.reduce(function(values, object) {
       if (isTracklistMetadata) {
@@ -839,9 +816,9 @@ var ListSubMenu = new Lang.Class({
       return values;
     }, {});
     return Object.keys(unique).length === objects.length;
-  },
+  }
 
-  _subMenuOpenStateChanged: function(menu, open) {
+  _subMenuOpenStateChanged(menu, open) {
     if (open) {
       this.actor.add_style_pseudo_class('open');
       this.actor.add_accessible_state(Atk.StateType.EXPANDED);
@@ -853,34 +830,32 @@ var ListSubMenu = new Lang.Class({
       this.actor.remove_style_pseudo_class('checked');
     }
   }
-});
+};
 
-var TrackList = new Lang.Class({
-    Name: "Tracklist",
-    Extends: ListSubMenu,
+var TrackList = class Tracklist extends ListSubMenu {
 
-  _init: function(label, player) {
-    this.parent(label);
+  constructor(label, player) {
+    super(label);
     this.player = player;
     this.parseMetadata = Util.parseMetadata;
-  },
+  }
 
-  showRatings: function(value) {
+  showRatings(value) {
     this.menu._getMenuItems().forEach(function(tracklistItem) {
       tracklistItem.showRatings(value);
     });
-  },
+  }
 
-  updateMetadata: function(UpdatedMetadata) {
+  updateMetadata(UpdatedMetadata) {
     let metadata = {};
     this.parseMetadata(UpdatedMetadata, metadata);
     let trackListItem = this.getItem(metadata.trackObj);
     if (trackListItem) {
       trackListItem.updateMetadata(metadata);
     }
-  },
+  }
 
-  loadTracklist: function(trackListMetaData, showRatings) {
+  loadTracklist(trackListMetaData, showRatings) {
     this.menu.removeAll();
     //As per spec all object paths MUST be unique.
     //If we don't have unique object paths reject the whole array.
@@ -905,19 +880,16 @@ var TrackList = new Lang.Class({
       }
     }
   }
+};
 
-});
+var Playlists = class Playlists extends ListSubMenu {
 
-var Playlists = new Lang.Class({
-    Name: "Playlists",
-    Extends: ListSubMenu,
-
-  _init: function(label, player) {
-    this.parent(label);
+  constructor(label, player) {
+    super(label);
     this.player = player;
-  },
+  }
 
-  loadPlaylists: function(playlists) {
+  loadPlaylists(playlists) {
     this.menu.removeAll();
     //As per spec all object paths MUST be unique.
     //If we don't have unique object paths reject the whole array.
@@ -940,43 +912,37 @@ var Playlists = new Lang.Class({
         this.setObjectActive(this.activeObject);
       }
     }
-  },
+  }
 
-  updatePlaylist: function(UpdatedPlaylist) {
+  updatePlaylist(UpdatedPlaylist) {
     let [obj, name] = UpdatedPlaylist;
     let playlistItem = this.getItem(obj);
     if (playlistItem) {
       playlistItem.updatePlaylistName(name);
     }
   }
+};
 
-});
+var PlaylistItem = class PlaylistItem extends PopupMenu.PopupBaseMenuItem {
 
-var PlaylistItem = new Lang.Class({
-    Name: "PlaylistItem",
-    Extends: PopupMenu.PopupBaseMenuItem,
-
-    _init: function (text, obj) {
-        this.parent();
+    constructor(text, obj) {
+        super();
         this.obj = obj;
         this.label = new St.Label({text: text});
         this.actor.add(this.label);
-    },
+    }
 
-    updatePlaylistName: function(name) {
+    updatePlaylistName(name) {
       if (this.label.text != name) {
         this.label.text = name;
       }
     }
+};
 
-});
+var TracklistItem = class TracklistItem extends PopupMenu.PopupBaseMenuItem {
 
-var TracklistItem = new Lang.Class({
-    Name: "TracklistItem",
-    Extends: PopupMenu.PopupBaseMenuItem,
-
-    _init: function (metadata, player) {
-        this.parent();
+    constructor(metadata, player) {
+        super();
         this.actor.child_set_property(this._ornamentLabel, "y-fill", false);
         this.actor.child_set_property(this._ornamentLabel, "y-align", St.Align.MIDDLE);
         this._player = player;
@@ -1026,9 +992,9 @@ var TracklistItem = new Lang.Class({
           }
         }
         this.updateMetadata(metadata);
-    },
+    }
 
-    updateMetadata: function(metadata) {
+    updateMetadata(metadata) {
       this._setCoverIconAsync(this._coverIcon, metadata.trackCoverUrl);
       this._setArtist(metadata.trackArtist);
       this._setTitle(metadata.trackTitle);
@@ -1040,27 +1006,27 @@ var TracklistItem = new Lang.Class({
       else {
         this.showRatings(false);
       }
-    },
+    }
 
-    _setArtist: function(artist) {
+    _setArtist(artist) {
       if (this._artistLabel.text != artist) {
         this._animateChange(this._artistLabel, 'text', artist);
       }
-    },
+    }
 
-    _setTitle: function(title) {
+    _setTitle(title) {
       if (this._titleLabel.text != title) {
         this._animateChange(this._titleLabel, 'text', title);
       }
-    },
+    }
 
-    _setAlbum: function(album) {
+    _setAlbum(album) {
       if (this._albumLabel.text != album) {
         this._animateChange(this._albumLabel, 'text', album);
       }
-    },
+    }
 
-    _buildStars: function(value) {
+    _buildStars(value) {
       // For Pithos versions without ratings support.
       if (value.constructor === String) {
         value = value == 'love' ? 5 : 0;
@@ -1078,12 +1044,12 @@ var TracklistItem = new Lang.Class({
           this._animateChange(starIcon, 'icon_name', icon_name);
           return false;
         }));
-        
+
       }
       this._rating = value;
-    },
+    }
 
-    _buildPithosRatings: function(rating) {
+    _buildPithosRatings(rating) {
       this._ratingBox.add_style_class_name('pithos-rating-box');
       this._ratingsIcon = new St.Icon({style_class: 'popup-menu-icon no-padding'});
       this._unRateButton = new St.Button({x_align: St.Align.MIDDLE,
@@ -1102,9 +1068,9 @@ var TracklistItem = new Lang.Class({
       }));
       this._unRateButton.hide();
       this._setPithosRating(rating);
-    },
+    }
 
-    _setPithosRating: function(rating) {
+    _setPithosRating(rating) {
       if (this._rating == rating) {
         return;
       }
@@ -1186,9 +1152,9 @@ var TracklistItem = new Lang.Class({
       }
       this._box.set_width(-1);
       this._rating = rating;
-    },
+    }
 
-  _setStarRating: function(value) {
+  _setStarRating(value) {
     // For Pithos versions without ratings support.
     if (value.constructor === String) {
       value = value == 'love' ? 5 : 0;
@@ -1207,9 +1173,9 @@ var TracklistItem = new Lang.Class({
         }));
       }
     }
-  },
+  }
 
-  showRatings: function(value) {
+  showRatings(value) {
     if (value && this._validRatings) {
       this._albumLabel.hide();
       this._ratingBox.show();
@@ -1219,5 +1185,4 @@ var TracklistItem = new Lang.Class({
       this._albumLabel.show();
     }
   }
-
-});
+};


### PR DESCRIPTION
GNOME Shell 3.32 removed Lang.class() and we should be using ES6 classes instead. See https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/361

This change is mostly automated by https://github.com/DreaminginCodeZH/gnome-shell-es6-class-codemod . I've verified this locally on my GNOME Shell 3.32.

Also updated the `shell-version` in `metadata.json` because I've no idea if this will work on 3.30, or even older releases. If someone was able to verify it works, we can add it back.

This change fixes #476.